### PR TITLE
Tweak the statement of an axiom to follow minor changes in saw-core

### DIFF
--- a/tests/saw/spec/handshake/handshake.saw
+++ b/tests/saw/spec/handshake/handshake.saw
@@ -38,7 +38,7 @@ let yices_debug = do { yices; print_goal; };
 
 // Workaround for If then else on nat
 let equalNat_ite = core_axiom
-  "\\(x y z : Nat) (b : Bool) -> eq Bool (equalNat x (ite Nat b y z)) (ite Bool b (equalNat x y) (equalNat x z))";
+  "(x y z : Nat) -> (b : Bool) -> EqTrue (boolEq (equalNat x (ite Nat b y z)) (ite Bool b (equalNat x y) (equalNat x z)))";
 
 // Low-level handshake_io correspondence proof
 let prove_handshake_io_lowlevel = do {


### PR DESCRIPTION
Tweak to the statement of an axiom used in the tls proof, made necessary by https://github.com/GaloisInc/saw-script/pull/1114